### PR TITLE
Improve Message.new_id algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ callee = Spell.connect(Crossbar.uri,
                        roles: [Spell.Role.Callee])
 
 # `call_register/2,3` synchronously registers the procedure.
-{:ok, registration} = Spell.call_register(subscriber, procedure)
+{:ok, registration} = Spell.call_register(callee, procedure)
 
 # Create a peer with the caller role.
 caller = Spell.connect(Crossbar.uri,

--- a/lib/spell/message.ex
+++ b/lib/spell/message.ex
@@ -218,13 +218,17 @@ defmodule Spell.Message do
 
   @doc """
   Return a new WAMP id.
+
+  To ensure the uniqueness of the new id we use :crypto.rand_bytes to generate
+  a random seed
+
+  TODO: improve `:random.uniform` using a Mersenne Twister PRNG algorithm
   """
   @spec new_id :: integer
   def new_id do
-    # TODO: hack to ensure the random generator is seeded -- will result in
-    # clock skew
-    :random.seed(:erlang.now())
-    (:math.pow(2, 53) |> round |> :random.uniform) - 1
+    << a :: 32, b :: 32, c :: 32 >> = :crypto.rand_bytes(12)
+    :random.seed(a,b,c)
+    ((:math.pow(2, 53) + 1) |> round |> :random.uniform) - 1
   end
 
   @doc """


### PR DESCRIPTION
Looking at the TODO on the `Message.new_id` I felt into the rabbit hole of the random number! I started to read around and I found this interesting article: http://www.neo.com/2014/02/24/pseudo-random-number-generation-in-elixir. In a nutshell It says that, using the elixir lib the best way to generate a Pseudo Random Number is `:crypto.rand_bytes`. Using `:crypto` we can have a random number without effect the Beam clock avoid to incur in possible clock skew.

An improvement is also to use a Mersenne Twister based PRNG algorithm to improve the limit of `:random.uniform`. Although that required using a third part lib (elixir doesn't provide yet an implementation of it) so I preferred not to add extra dependencies.
