### PR TITLE
Fix pubsub example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ otp_release:
 sudo: true
 before_script:
   - sudo pip install crossbar
+script: "mix test && mix spell.example.pubsub"
 after_success:
   - pkill -f crossbar
 notifications:

--- a/examples/pubsub.exs
+++ b/examples/pubsub.exs
@@ -108,7 +108,7 @@ defmodule PubSub do
   """
   def new_peer(roles, options) do
     uri   = Keyword.get(options, :uri, Crossbar.uri)
-    realm = Keyword.get(options, :realm, Crossbar.realm)
+    realm = Keyword.get(options, :realm, Crossbar.get_realm())
     Spell.connect(uri, realm: realm, roles: roles)
   end
 

--- a/lib/spell.ex
+++ b/lib/spell.ex
@@ -47,6 +47,7 @@ defmodule Spell do
   ### Serializers
 
     * JSON: `Spell.Serializer.JSON`
+    * MessagePack: `Spell.Serializer.MessagePack`
 
   See `Spell.Serializer` for how to create new serializers.
 


### PR DESCRIPTION
Simple fix for pubsub example. Also added example run in Travis. 
When we add more examples we should add a task `mix spell.examples` to run all of them instead of adding every single example in `.travis.yml`.