### PR TITLE
Clean config 29

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,10 +2,6 @@ use Mix.Config
 
 log_level = :info
 
-config :spell,
-  serializer: Spell.Serializer.JSON,
-  transport: Spell.Transport.WebSocket
-
 config :logger,
   # handle_otp_reports: true,
   # handle_sasl_reports: true,

--- a/lib/crossbar.ex
+++ b/lib/crossbar.ex
@@ -265,7 +265,7 @@ defmodule Crossbar do
   defp await(config \\ get_config(:websocket), interval \\ 250, retries \\ 40)
   defp await(_config, _interval, 0), do: {:error, :timeout}
   defp await(config, interval, retries) do
-    case Spell.Transport.WebSocket.connect(Application.get_env(:spell, :serializer), config) do
+    case Spell.Transport.WebSocket.connect(Spell.Config.serializer, config) do
       {:error, :econnrefused} ->
         # Flush the error message of the linked websocket crashing
         receive do
@@ -289,7 +289,7 @@ defmodule Crossbar do
   end
 
   defp app_transport do
-    case Application.get_env(:spell, :transport) do
+    case Spell.Config.transport do
       Spell.Transport.RawSocket -> :raw_socket
       _ -> :websocket
     end

--- a/lib/crossbar.ex
+++ b/lib/crossbar.ex
@@ -91,19 +91,9 @@ defmodule Crossbar do
   The default value of `8080` for websocket and `9000` for raw_socket can be
   overrode using the environment variables `CROSSBAR_PORT_WS` and `CROSSBAR_PORT_RS`.
   """
-  @spec get_port(:websocket | :raw_socket) :: :inet.port
-  def get_port(:websocket) do
-    case System.get_env("CROSSBAR_PORT_WS") do
-      nil -> 8080
-      port when is_binary(port) -> String.to_integer(port)
-    end
-  end
-  def get_port(:raw_socket) do
-    case System.get_env("CROSSBAR_PORT_RS") do
-      nil -> 9000
-      port when is_binary(port) -> String.to_integer(port)
-    end
-  end
+  @spec get_port(String.t) :: :inet.port
+  def get_port("websocket"), do: get_port_from_env("CROSSBAR_PORT_WS", 8080)
+  def get_port("rawsocket"), do: get_port_from_env("CROSSBAR_PORT_RS", 9000)
 
   @doc """
   Return the port which the crossbar raw_socket auth is listening on.
@@ -111,13 +101,8 @@ defmodule Crossbar do
   The default value of `9001` for raw_socket can be
   overrode using the environment variable `CROSSBAR_AUTH_PORT_RS`.
   """
-  @spec get_port(:raw_socket) :: :inet.port
-  def get_auth_port(:raw_socket) do
-    case System.get_env("CROSSBAR_AUTH_PORT_RS") do
-      nil -> 9001
-      port when is_binary(port) -> String.to_integer(port)
-    end
-  end
+  @spec get_auth_port(String.t) :: :inet.port
+  def get_auth_port("rawsocket"), do: get_port_from_env("CROSSBAR_AUTH_PORT_RS", 9001)
 
   @doc """
   Return the crossbar host.
@@ -128,14 +113,14 @@ defmodule Crossbar do
   @doc """
   Get the crossbar resource path.
   """
-  @spec get_path(:websocket | :raw_socket) :: String.t
-  def get_path(:websocket), do: "/ws"
-  def get_path(:raw_socket), do: ""
+  @spec get_path(String.t) :: String.t
+  def get_path("websocket"), do: "/ws"
+  def get_path("rawsocket"), do: ""
 
   @doc """
   Get the crossbar config.
   """
-  @spec get_config(:websocket | :raw_socket) :: Keyword.t
+  @spec get_config(String.t) :: Keyword.t
   def get_config(transport \\ app_transport) do
     [host: get_host(),
      port: get_port(transport),
@@ -146,7 +131,7 @@ defmodule Crossbar do
   @doc """
   Get the config as a uri.
   """
-  @spec uri(Keyword.t, :websocket | :raw_socket) :: String.t
+  @spec uri(Keyword.t, String.t) :: String.t
   def uri(options \\ get_config(), transport \\ app_transport) do
     uri_for(transport, options)
   end
@@ -156,7 +141,7 @@ defmodule Crossbar do
 
   TODO: support this as part of templating out the config file.
   """
-  @spec uri_auth(Keyword.t, :websocket | :raw_socket) :: String.t
+  @spec uri_auth(Keyword.t, String.t) :: String.t
   def uri_auth(options \\ get_config(), transport \\ app_transport) do
     auth_uri_for(transport, options)
   end
@@ -262,7 +247,7 @@ defmodule Crossbar do
   EEx.function_from_file :defp, :template_config, @crossbar_template, [:assigns]
 
   @spec await(Keyword.t) :: :ok | {:error, :timeout | term}
-  defp await(config \\ get_config(:websocket), interval \\ 250, retries \\ 40)
+  defp await(config \\ get_config("websocket"), interval \\ 250, retries \\ 40)
   defp await(_config, _interval, 0), do: {:error, :timeout}
   defp await(config, interval, retries) do
     case Spell.Transport.WebSocket.connect(Spell.Config.serializer, config) do
@@ -288,35 +273,37 @@ defmodule Crossbar do
      :stderr_to_stdout]
   end
 
-  defp app_transport do
-    case Spell.Config.transport do
-      Spell.Transport.RawSocket -> :raw_socket
-      _ -> :websocket
-    end
-  end
+  defp app_transport, do: Spell.Config.transport_name
 
   defp get_all_config do
     [host: get_host(),
-     websocket_port: get_port(:websocket),
-     raw_socket_port: get_port(:raw_socket),
-     raw_socket_auth_port: get_auth_port(:raw_socket),
-     websocket_path: get_path(:websocket),
+     websocket_port: get_port("websocket"),
+     raw_socket_port: get_port("rawsocket"),
+     raw_socket_auth_port: get_auth_port("rawsocket"),
+     websocket_path: get_path("websocket"),
      realm: get_realm()]
   end
 
-  defp uri_for(:websocket, options) do
+  defp uri_for("websocket", options) do
     "ws://#{options[:host]}:#{options[:port]}#{options[:path]}"
   end
 
-  defp uri_for(:raw_socket, options) do
+  defp uri_for("rawsocket", options) do
     "raw_socket://#{options[:host]}:#{options[:port]}"
   end
 
-  defp auth_uri_for(:websocket, options) do
-    uri_for(:websocket, options) <> "_auth"
+  defp auth_uri_for("websocket", options) do
+    uri_for("websocket", options) <> "_auth"
   end
 
-  defp auth_uri_for(:raw_socket, options) do
-    uri_for(:raw_socket, Keyword.put(options, :port, get_auth_port(:raw_socket)))
+  defp auth_uri_for("rawsocket", options) do
+    uri_for("rawsocket", Keyword.put(options, :port, get_auth_port("rawsocket")))
+  end
+
+  defp get_port_from_env(env_var, default) do
+    case System.get_env(env_var) do
+      nil -> default
+      port when is_binary(port) -> String.to_integer(port)
+    end
   end
 end

--- a/lib/mix/tasks/test.integration.ex
+++ b/lib/mix/tasks/test.integration.ex
@@ -1,23 +1,15 @@
 defmodule Mix.Tasks.Test.Integration do
   use Mix.Task
 
-  @available_transports  ["web_socket", "raw_socket"]
+  @available_transports  ["websocket", "rawsocket"]
   @available_serializers ["json", "msgpack"]
 
-  def transport_module(nil), do: transport_module("web_socket")
-  def transport_module("web_socket"), do: Spell.Transport.WebSocket
-  def transport_module("raw_socket"), do: Spell.Transport.RawSocket
-
-  def serializer_module(nil), do: serializer_module("json")
-  def serializer_module("json"), do: Spell.Serializer.JSON
-  def serializer_module("msgpack"), do: Spell.Serializer.MessagePack
-
   def set_transport do
-    Application.put_env(:spell, :transport, transport_module(System.get_env("TRANSPORT")))
+    Application.put_env(:spell, :transport, System.get_env("TRANSPORT"))
   end
 
   def set_serializer do
-    Application.put_env(:spell, :serializer, serializer_module(System.get_env("SERIALIZER")))
+    Application.put_env(:spell, :serializer, System.get_env("SERIALIZER"))
   end
 
   def run(args) do

--- a/lib/mix/tasks/test.integration.ex
+++ b/lib/mix/tasks/test.integration.ex
@@ -1,9 +1,6 @@
 defmodule Mix.Tasks.Test.Integration do
   use Mix.Task
 
-  @available_transports  ["websocket", "rawsocket"]
-  @available_serializers ["json", "msgpack"]
-
   def set_transport do
     Application.put_env(:spell, :transport, System.get_env("TRANSPORT"))
   end
@@ -25,21 +22,8 @@ defmodule Mix.Tasks.Test.Integration do
     end
   end
 
-  defp transport_list do
-    case System.get_env("TRANSPORT") do
-      transport when transport in @available_transports -> [transport]
-      "all" -> @available_transports
-      nil -> @available_transports
-    end
-  end
-
-  defp serializer_list do
-    case System.get_env("SERIALIZER") do
-      serializer when serializer in @available_serializers -> [serializer]
-      "all" -> @available_serializers
-      nil -> @available_serializers
-    end
-  end
+  defp transport_list, do: get_list_from_env("TRANSPORT", Spell.Config.available_transports)
+  defp serializer_list, do: get_list_from_env("SERIALIZER", Spell.Config.available_serializers)
 
   defp run_integration(args, transport: transport, serializer: serializer) do
     IO.puts "==> Running integration tests for transport=#{transport}, serializer=#{serializer}"
@@ -47,5 +31,13 @@ defmodule Mix.Tasks.Test.Integration do
     System.cmd "mix", ["test"|args],
                        into: IO.binstream(:stdio, :line),
                        env: [{"TRANSPORT", transport}, {"SERIALIZER", serializer}]
+  end
+
+  defp get_list_from_env(env_var, default_list) do
+    case System.get_env(env_var) do
+      "all" -> default_list
+      nil -> default_list
+      value -> [value]
+    end
   end
 end

--- a/lib/spell.ex
+++ b/lib/spell.ex
@@ -204,7 +204,7 @@ defmodule Spell do
       {:ok, role_options} ->
         session_options = Keyword.take(options, [:realm, :authentication])
         %{transport: Keyword.get(options, :transport),
-          serializer: Keyword.get(options, :serializer, Application.get_env(:spell, :serializer)),
+          serializer: Keyword.get(options, :serializer, Spell.Config.serializer),
           owner: Keyword.get(options, :owner),
           role: %{options: Keyword.put_new(role_options, Role.Session,
                                            session_options),
@@ -225,7 +225,7 @@ defmodule Spell do
 
   defp normalize_options(%{transport: transport_options} = options)
       when is_list(transport_options) do
-    %{options | transport: %{module: Application.get_env(:spell, :transport),
+    %{options | transport: %{module: Spell.Config.transport,
                              options: transport_options}}
       |> normalize_options()
   end

--- a/lib/spell/config.ex
+++ b/lib/spell/config.ex
@@ -1,0 +1,26 @@
+defmodule Spell.Config do
+  @moduledoc """
+  This module helps to get the configurable modules from within Spell
+  """
+  @doc """
+  Gets the serializer module
+  """
+  def serializer do
+    serializer(Application.get_env(:spell, :serializer))
+  end
+
+  def serializer(nil), do: serializer("json")
+  def serializer("json"), do: Spell.Serializer.JSON
+  def serializer("msgpack"), do: Spell.Serializer.MessagePack
+
+  @doc """
+  Gets the transport module
+  """
+  def transport do
+    transport(Application.get_env(:spell, :transport))
+  end
+
+  def transport(nil), do: transport("websocket")
+  def transport("websocket"), do: Spell.Transport.WebSocket
+  def transport("rawsocket"), do: Spell.Transport.RawSocket
+end

--- a/lib/spell/config.ex
+++ b/lib/spell/config.ex
@@ -2,25 +2,33 @@ defmodule Spell.Config do
   @moduledoc """
   This module helps to get the configurable modules from within Spell
   """
+
+  def available_serializers, do: ["json", "msgpack"]
+  def available_transports,  do: ["websocket", "rawsocket"]
+
+  @doc """
+  Gets the serializer module name
+  """
+  def serializer_name, do: Application.get_env(:spell, :serializer) || "json"
+
   @doc """
   Gets the serializer module
   """
-  def serializer do
-    serializer(Application.get_env(:spell, :serializer))
-  end
+  def serializer, do: serializer(serializer_name)
 
-  def serializer(nil), do: serializer("json")
   def serializer("json"), do: Spell.Serializer.JSON
   def serializer("msgpack"), do: Spell.Serializer.MessagePack
 
   @doc """
+  Gets the transport module name
+  """
+  def transport_name, do: Application.get_env(:spell, :transport) || "websocket"
+
+  @doc """
   Gets the transport module
   """
-  def transport do
-    transport(Application.get_env(:spell, :transport))
-  end
+  def transport, do: transport(transport_name)
 
-  def transport(nil), do: transport("websocket")
   def transport("websocket"), do: Spell.Transport.WebSocket
   def transport("rawsocket"), do: Spell.Transport.RawSocket
 end

--- a/lib/spell/transport/raw_socket.ex
+++ b/lib/spell/transport/raw_socket.ex
@@ -82,6 +82,10 @@ defmodule Spell.Transport.RawSocket do
     {:stop, {:remote, :closed}, state}
   end
 
+  def terminate(_reason, %__MODULE__{socket: socket}) do
+    :gen_tcp.close(socket)
+    :ok
+  end
   # Private Functions
 
   defp handshake(%__MODULE__{socket: socket, serializer_id: serializer_id, max_length: max_length} = state) do

--- a/test/integration/spell/connect_test.exs
+++ b/test/integration/spell/connect_test.exs
@@ -1,8 +1,8 @@
 defmodule Spell.ConnectTest do
   use ExUnit.Case
 
-  @transport  Application.get_env(:spell, :transport)
-  @serializer Application.get_env(:spell, :serializer)
+  @transport  Spell.Config.transport
+  @serializer Spell.Config.serializer
   @bad_host   "192.168.100.100"
   @bad_uri    "ws://" <> @bad_host
 

--- a/test/unit/spell/transport/raw_socket_test.exs
+++ b/test/unit/spell/transport/raw_socket_test.exs
@@ -3,7 +3,7 @@ defmodule Spell.Transport.RawSocketTest do
 
   alias Spell.Transport.RawSocket
 
-  @serializer Application.get_env(:spell, :serializer)
+  @serializer Spell.Config.serializer
 
   test "new/1 -- bad host" do
     assert {:error, :nxdomain} =

--- a/test/unit/spell/transport/websocket_test.exs
+++ b/test/unit/spell/transport/websocket_test.exs
@@ -3,7 +3,7 @@ defmodule Spell.Transport.WebSocketTest do
 
   alias Spell.Transport.WebSocket
 
-  @serializer Application.get_env(:spell, :serializer)
+  @serializer Spell.Config.serializer
 
   setup do: {:ok, Crossbar.get_config()}
 


### PR DESCRIPTION
The configuration for default serializer and transport looked like:

```elixir
config :spell,
  serializer: Spell.Serializer.JSON,
  transport: Spell.Transport.WebSocket
```

We want to change it to something less explicit like:

```elixir
config :spell,
  serializer: "json"
  transport: "websocket"
```

Also, it was inside spell. It turns out that the config defined in spell 'config.config.exs' is not used when spell is used in another project as a dependency. As we cannot rely on this, we need to supply defaults. I added the `Spell.Config` module when we do all this. It also keeps the list of available transports and serializers as @mtanzi suggested.

I also clean a bit `crossbar.ex`