### PR TITLE
protect rawsocket transport against overflow

### DIFF
--- a/lib/spell/transport/raw_socket.ex
+++ b/lib/spell/transport/raw_socket.ex
@@ -61,6 +61,7 @@ defmodule Spell.Transport.RawSocket do
   def handle_info({:tcp, socket, raw_message}, %__MODULE__{socket: socket} = state) do
     Logger.debug(fn -> "Received message over socket: #{inspect(raw_message)}" end)
     :ok = handle_messages(to_string(raw_message), state)
+    :inet.setopts(state.socket, active: :once)
     {:noreply, state}
   end
 
@@ -111,7 +112,7 @@ defmodule Spell.Transport.RawSocket do
   # SSSS = echo the serializer value requested by the Client
   # RRRR RRRR RRRR RRRR = reserved and MUST be all zeros for now
   defp process_handshake_response({:ok, <<127,max_length::4,ser_id::4,0,0>>}, %__MODULE__{serializer_id: ser_id} = state) do
-    :inet.setopts(state.socket, active: true)
+    :inet.setopts(state.socket, active: :once)
     :proc_lib.init_ack({:ok, self})
     :gen_server.enter_loop(__MODULE__, [], %{state | router_max_length: max_length})
   end


### PR DESCRIPTION
From erlang docs
 Note that {active, true} mode provides no flow control; a fast sender could easily overflow the receiver with incoming messages. The same is true of {active, N} mode while the message count is greater than zero. Use active mode only if your high-level protocol provides its own flow control (for instance, acknowledging received messages) or the amount of data exchanged is small. {active, false} mode, use of the {active, once} mode or {active, N} mode with values of N appropriate for the application provides flow control; the other side will not be able send faster than the receiver can read. 

With this change we make sure we only receive one message at a time, so we are protected against overflow