### PR TITLE
add docs for pattern-based subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,30 @@ for peer <- [subscriber, publisher], do: Spell.close(peer)
 
 See `Spell.Role.Publisher` and `Spell.Role.Subscriber` for more information.
 
+#### Pattern-based subscriptions
+
+By default, peers subscribe to topics using an exact matching policy. Using
+pattern-based subscriptions a peer can receive messages that match certain
+criteria.
+
+```elixir
+# assuming we have a subscriber peer connected
+
+# exact match
+{:ok, subscription} = Spell.call_subscribe(subscriber, "com.spell.my_topic")
+# subscriber will receive messages published in the "com.spell.my_topic" topic
+
+# prefix match
+{:ok, subscription} = Spell.call_subscribe(subscriber, "com.spell.my_topic_prefix", options: %{match: :prefix})
+# subscriber will receive messages published in topics:
+# "com.spell.my_topic_prefix.foo",  "com.spell.my_topic_prefix.bar", ...
+
+# wildcard match
+{:ok, subscription} = Spell.call_subscribe(subscriber, "com.spell..my_topic", options: %{match: :wildcard})
+# subscriber will receive messages published in topics:
+# "com.spell.foo.my_topic", "com.spell.bar.my_topic", ...
+```
+
 ### RPC
 
 RPC allows a caller to call a procedure using a remote callee.

--- a/examples/pubsub.exs
+++ b/examples/pubsub.exs
@@ -81,7 +81,7 @@ defmodule PubSub do
     defp init(topics, options) when is_list(topics) do
       {:ok, subscriber} = PubSub.new_peer([Spell.Role.Subscriber], options)
       for topic <- topics do
-        {:ok, _publication} = Spell.call_subscribe(subscriber, topic)
+        {:ok, _publication} = Spell.call_subscribe(subscriber, topic, options)
       end
       %__MODULE__{subscriber: subscriber, topics: topics}
         |> struct(options)
@@ -162,6 +162,9 @@ Logger.info("Starting the Crossbar.io test server...")
 # Start the logging subscriber and subscribe it to the two active topics
 {:ok, subscriber} = SubLogger.start_link([randoms_topic, command_line_topic])
 
+# Start the logging subscriber and subscribe it to the two active topics using pattern
+{:ok, wildcard_subscriber} = SubLogger.start_link("com.spell.example", options: %{match: :prefix})
+
 # Let it happen
 :timer.sleep(10000)
 
@@ -169,7 +172,8 @@ Logger.info("DONE... Stopping peers")
 # Kill all the processes with a `:stop` message
 for pid <- [randoms_publisher,
             command_line_publisher,
-            subscriber], do: send(pid, :stop)
+            subscriber,
+            wildcard_subscriber], do: send(pid, :stop)
 
 Logger.info("DONE... Stopping Crossbar.io server")
 # Stop the crossbar.io testing server


### PR DESCRIPTION
Since pattern-based subscriptions are basically sending options in the subscribe message, they just work!

I added an explanation in the readme and a pattern base subscriber in the pubsub example.