### PR TITLE
Makes connection timeouts configurable.

### DIFF
--- a/lib/spell.ex
+++ b/lib/spell.ex
@@ -122,6 +122,7 @@ defmodule Spell do
      retry connecting
    * `:retry_interval = #{@default_retry_interval} :: integer` inteveral
      in milliseconds between retries
+   * `:timeout = 2000 :: integer` connection timeout for a peer
    * `:authentication :: Keyword.t`, defaults to `[]`
        * `:id :: String.t` the `authid` to authenticate with
        * `:schemes :: Keyword.t` the authentication schemes supported. See

--- a/lib/spell/role/session.ex
+++ b/lib/spell/role/session.ex
@@ -37,6 +37,7 @@ defmodule Spell.Role.Session do
 
   @goodbye_close_realm "wamp.error.close_realm"
   @goodbye_and_out     "wamp.error.goodbye_and_out"
+  @default_timeout 2000
 
   # Public Functions
 
@@ -61,7 +62,7 @@ defmodule Spell.Role.Session do
   """
   @spec call_goodbye(pid, Keyword.t) :: {:ok, Message.t} | {:error, :timeout}
   def call_goodbye(peer, options \\ []) do
-    timeout = Keyword.get(options, :timeout, 1000)
+    timeout = Keyword.get(options, :timeout, config_timeout)
     :ok = cast_goodbye(peer, options)
     Peer.await(peer, :goodbye, timeout)
   end
@@ -71,7 +72,7 @@ defmodule Spell.Role.Session do
   established.
   """
   @spec await_welcome(pid) :: {:ok, Message.t} | {:error, :timeout}
-  def await_welcome(peer), do: Peer.await(peer, :welcome)
+  def await_welcome(peer), do: Peer.await(peer, :welcome, config_timeout)
 
   def receive_welcome(peer) do
     receive_message peer, :welcome do
@@ -203,4 +204,11 @@ defmodule Spell.Role.Session do
     end
   end
 
+  @spec config_timeout() :: integer
+  defp config_timeout do
+    case Application.get_env(:spell, :timeout) do
+      nil -> @default_timeout
+      i -> i
+    end
+  end
 end

--- a/lib/spell/role/session.ex
+++ b/lib/spell/role/session.ex
@@ -206,9 +206,6 @@ defmodule Spell.Role.Session do
 
   @spec config_timeout() :: integer
   defp config_timeout do
-    case Application.get_env(:spell, :timeout) do
-      nil -> @default_timeout
-      i -> i
-    end
+    Application.get_env(:spell, :timeout, @default_timeout)
   end
 end

--- a/lib/spell/role/subscriber.ex
+++ b/lib/spell/role/subscriber.ex
@@ -15,7 +15,7 @@ defmodule Spell.Role.Subscriber do
              unsubscribe_requests: HashDict.new(),
              subscriptions: HashDict.new()]
 
-  @timeout 1000
+  @default_timeout 1000
 
   # Public Interface
 
@@ -46,7 +46,7 @@ defmodule Spell.Role.Subscriber do
                              args: [^subscribe_id, subscription]}} ->
         {:ok, subscription}
     after
-      @timeout -> {:error, :timeout}
+      config_timeout -> {:error, :timeout}
     end
   end
 
@@ -224,4 +224,11 @@ defmodule Spell.Role.Subscriber do
                 args: [Message.new_id(), subscription])
   end
 
+  @spec config_timeout() :: integer
+  defp config_timeout do
+    case Application.get_env(:spell, :timeout) do
+      nil -> @default_timeout
+      i -> i
+    end
+  end
 end

--- a/lib/spell/role/subscriber.ex
+++ b/lib/spell/role/subscriber.ex
@@ -226,9 +226,6 @@ defmodule Spell.Role.Subscriber do
 
   @spec config_timeout() :: integer
   defp config_timeout do
-    case Application.get_env(:spell, :timeout) do
-      nil -> @default_timeout
-      i -> i
-    end
+    Application.get_env(:spell, :timeout, @default_timeout)
   end
 end


### PR DESCRIPTION
Hardcoded timeouts in Peer and Session may be problematic.

This commit adds a configurable timeout that can be used by any role if
needed. While there's no discrimination between different timeout
policies (e.g. you may want a session timeout to last longer than a peer one), it gives
at least the ability to tweak that value on a global level (which is
usually enough).