### PR TITLE
Document using Spell and specifying dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ Spell uses GitHub [issues](https://github.com/MyMedsAndMe/spell/issues) and
 Spell has a mailing list at spell@librelist.com; general questions or ideas are
 welcome there. See [librelist](http://librelist.com/) for how to sign up.
 
+## Using Spell with your Elixir Project
+
+To use Spell from within your Elixir library add, add it to your `mix.exs` deps,
+along with the required transport and serialization libraries:
+
+```elixir
+defp deps do
+  [
+    ...
+    # Required:
+    {:spell, "~> 0.1"},
+    # Required if using the websocket transport:
+    {:websocket_client, github: "jeremyong/websocket_client", tag: "v0.7"},
+    # Required if using the JSON serializer:
+    {:poison, "~> 1.4"},
+    # Required if using the msgpack serializer:
+    {:msgpax, "~> 0.7"}
+  ]
+end
+```
+
+Fetch the dependencies by running:
+
+```
+$ mix deps.get
+```
+
 ## How it Works
 
 You can run the examples you're about to run into, though first you'll need

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Spell.Mixfile do
      elixir: "~> 1.0",
      description: description,
      package: package,
-     deps: deps,
+     deps: deps(Mix.env),
      aliases: aliases,
      docs: docs,
      preferred_cli_env: ["test.all": :test,
@@ -23,7 +23,6 @@ defmodule Spell.Mixfile do
   def application do
     [applications: [:logger,
                     :websocket_client,
-                    :poison,
                     :pbkdf2],
     mod: {Spell, []}]
   end
@@ -47,19 +46,24 @@ defmodule Spell.Mixfile do
   end
 
   # TODO: allow transport/serialization deps to be filtered out
-  defp deps do
+  defp deps(:prod) do
     [
-     # Req'd by: `Spell.Transport.Websocket`
-     {:websocket_client, github: "jeremyong/websocket_client", tag: "v0.7"},
-     # Req'd by: `Spell.Serializer.JSON`
-     {:poison, "~> 1.4.0"},
-     # Req'd by: `Spell.Serializer.MessagePack`
-     {:msgpax, "~> 0.7"},
      # Req'd by: `Spell.Authentication.CRA`
-     {:pbkdf2, github: "pma/erlang-pbkdf2", branch: "master"},
-     # Doc deps
-     {:earmark, "~> 0.1", only: :doc},
-     {:ex_doc, "~> 0.7", only: :doc}
+     {:pbkdf2, github: "pma/erlang-pbkdf2", branch: "master"}
+    ]
+  end
+
+  defp deps(_) do
+    deps(:prod) ++ [
+      # Req'd by: `Spell.Transport.Websocket`
+      {:websocket_client, github: "jeremyong/websocket_client", tag: "v0.7"},
+      # Req'd by: `Spell.Serializer.JSON`
+      {:poison, "~> 1.4"},
+      # Req'd by: `Spell.Serializer.MessagePack`
+      {:msgpax, "~> 0.7"},
+      # Doc deps
+      {:earmark, "~> 0.1", only: :doc},
+      {:ex_doc, "~> 0.7", only: :doc}
     ]
   end
 


### PR DESCRIPTION
Remove optional dependencies from requirements, requiring the library user to specify them explicitly.