### PR TITLE
update and reorg docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,8 +62,8 @@ defmodule Spell.Mixfile do
       # Req'd by: `Spell.Serializer.MessagePack`
       {:msgpax, "~> 0.7"},
       # Doc deps
-      {:earmark, "~> 0.1", only: :doc},
-      {:ex_doc, "~> 0.7", only: :doc}
+      {:earmark, "~> 0.2", only: :doc},
+      {:ex_doc, "~> 0.11", only: :doc}
     ]
   end
 
@@ -76,9 +76,7 @@ defmodule Spell.Mixfile do
   end
 
   defp docs do
-    [
-        # TODO: change markdown compiler to once that supports gfm
-        #readme: "README.md"
-    ]
+    [main: "overview",
+     extras: ["README.md": [title: "Overview", path: "overview"]]]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.1.15"},
-  "ex_doc": {:hex, :ex_doc, "0.7.2"},
+%{"earmark": {:hex, :earmark, "0.2.1"},
+  "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "msgpax": {:hex, :msgpax, "0.7.0"},
   "pbkdf2": {:git, "git://github.com/pma/erlang-pbkdf2.git", "93b290d72b107747c717fb1f55811d2ebc1b73ed", [branch: "master"]},
   "poison": {:hex, :poison, "1.4.0"},


### PR DESCRIPTION
README.md is now used as the the documentation overview. (earmark supports GFM!)

Resolves #4 