### PR TITLE
Gracefully handle websocket :ping messages

### DIFF
--- a/lib/spell/transport/websocket.ex
+++ b/lib/spell/transport/websocket.ex
@@ -61,6 +61,9 @@ defmodule Spell.Transport.WebSocket do
     {:ok, %{owner: owner, serializer_info: serializer_info}}
   end
 
+  def websocket_handle({:ping, _}, _conn_state, state) do
+    {:ok, state}
+  end
   def websocket_handle({frame_type, raw_message}, _conn_state, state)
       when frame_type in [:text, :binary] do
     :ok = send_to_owner(state.owner, {:message, raw_message})


### PR DESCRIPTION
The current websocket handler crashes when a WS ping comes in; this PR addresses that case. There is no need to send a :pong, websocket_client does this for us already.

How to reproduce:
```
Spell.connect("wss://api.poloniex.com", realm: "realm1")
```
